### PR TITLE
Fix rethrow error in fetchStreamShards

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ class DynamoDBStream extends EventEmitter {
 						lastShardId = null // break out of loop; leave any remaining new shards for next call
 						break
 					default:
-						throw e
+						throw error
 				}
 			}
 		} while (lastShardId)


### PR DESCRIPTION
Fix wrong variable name when re-throwing non-throttling exceptions caught in `fetchStreamShards` function.